### PR TITLE
feat: use SixLabors.ImageSharp for arbitrary colour quantisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.idea
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/TomodachiDrawer.Core/ColourPalette.cs
+++ b/TomodachiDrawer.Core/ColourPalette.cs
@@ -184,55 +184,47 @@ namespace TomodachiDrawer.Core
         /// <returns>2D array of PaletteColour? [x, y] of the appropriate colours.</returns>
         public PaletteColour?[,] QuantizeImage(SKBitmap source, QuantizerSettings quantizerSettings)
         {
+            int width = source.Width, height = source.Height;
+            
             if (quantizerSettings.quantizerName == "Arbitrary")
             {
                 if (quantizerSettings.colourCount == null)
                     throw new ArgumentNullException(nameof(quantizerSettings.colourCount), "colourCount must be set for Arbitrary quantizer");
+
                 SKBitmap quantized = ArbitraryColourQuantizer.Quantize(source, (int)quantizerSettings.colourCount, quantizerSettings.useDithering ?? default);
-                // need to make our palette now.
-                // Find all distinct colours in the image and make the PaletteColour's
-                var skToPalette = MemoryMarshal.Cast<byte, SKColor>(quantized.GetPixelSpan())
-                    .ToArray()
+                SKColor[] pixels = quantized.Pixels;
+
+                var skToPalette = pixels
                     .Where(c => c.Alpha > 128)
                     .Distinct()
                     .ToDictionary(
                         d => d,
                         d => new PaletteColour($"({d.Red}, {d.Green}, {d.Blue})", d.Red, d.Green, d.Blue, null, null, d, true)
                     );
-                var output = new PaletteColour?[source.Width, source.Height];
-                for (int x = 0; x < quantized.Width; x++)
+
+                var output = new PaletteColour?[width, height];
+                for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
                 {
-                    for (int y = 0; y < quantized.Height; y++)
-                    {
-                        var pixel = quantized.GetPixel(x, y);
-                        if (pixel.Alpha <= 128)
-                            output[x, y] = null;
-                        else
-                            output[x, y] = skToPalette[pixel];
-                    }
+                    var pixel = pixels[y * width + x];
+                    output[x, y] = pixel.Alpha > 128 ? skToPalette[pixel] : null;
                 }
+
                 return output;
             }
             else
             {
                 var quantizer = Quantizers[quantizerSettings.quantizerName](Colours);
-                var result = new PaletteColour?[source.Width, source.Height];
+                SKColor[] pixels = source.Pixels;
 
-                // TODO: GetPixel is slow
-                for (int x = 0; x < source.Width; x++)
+                var result = new PaletteColour?[width, height];
+                for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
                 {
-                    for (int y = 0; y < source.Height; y++)
-                    {
-                        var pixel = source.GetPixel(x, y);
-                        if (pixel.Alpha <= 128)
-                            result[x, y] = null;
-                        else
-                            result[x, y] = quantizer.FindClosestColour(
-                                pixel.Red,
-                                pixel.Green,
-                                pixel.Blue
-                            );
-                    }
+                    var pixel = pixels[y * width + x];
+                    result[x, y] = pixel.Alpha > 128
+                        ? quantizer.FindClosestColour(pixel.Red, pixel.Green, pixel.Blue)
+                        : null;
                 }
 
                 return result;

--- a/TomodachiDrawer.Core/ColourPalette.cs
+++ b/TomodachiDrawer.Core/ColourPalette.cs
@@ -190,21 +190,15 @@ namespace TomodachiDrawer.Core
                     throw new ArgumentNullException(nameof(quantizerSettings.colourCount), "colourCount must be set for Arbitrary quantizer");
                 SKBitmap quantized = ArbitraryColourQuantizer.Quantize(source, (int)quantizerSettings.colourCount, quantizerSettings.useDithering ?? default);
                 // need to make our palette now.
-                // Find all distinct colours in the image
-                var distinctColours = new HashSet<SKColor>();
-                // this is slightly better than before
-                var span = MemoryMarshal.Cast<byte, SKColor>(quantized.GetPixelSpan());
-                foreach (var pixel in span)
-                {
-                    if (pixel.Alpha > 128)
-                        distinctColours.Add(pixel);
-                }
-                // make the PaletteColour's
-                var skToPalette  = new Dictionary<SKColor, PaletteColour>();
-                foreach (var d in distinctColours)
-                {
-                    skToPalette[d] = new PaletteColour($"({d.Red}, {d.Green}, {d.Blue})", d.Red, d.Green, d.Blue, null, null, d, true);
-                }
+                // Find all distinct colours in the image and make the PaletteColour's
+                var skToPalette = MemoryMarshal.Cast<byte, SKColor>(quantized.GetPixelSpan())
+                    .ToArray()
+                    .Where(c => c.Alpha > 128)
+                    .Distinct()
+                    .ToDictionary(
+                        d => d,
+                        d => new PaletteColour($"({d.Red}, {d.Green}, {d.Blue})", d.Red, d.Green, d.Blue, null, null, d, true)
+                    );
                 var output = new PaletteColour?[source.Width, source.Height];
                 for (int x = 0; x < quantized.Width; x++)
                 {

--- a/TomodachiDrawer.Core/ColourPalette.cs
+++ b/TomodachiDrawer.Core/ColourPalette.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using System.Runtime.InteropServices;
+using SkiaSharp;
 using TomodachiDrawer.Core.ImageProcessing;
 using TomodachiDrawer.Core.ImageProcessing.Denoising;
 using TomodachiDrawer.Core.ImageProcessing.Quantizers;
@@ -187,19 +188,16 @@ namespace TomodachiDrawer.Core
             {
                 if (quantizerSettings.colourCount == null)
                     throw new ArgumentNullException(nameof(quantizerSettings.colourCount), "colourCount must be set for Arbitrary quantizer");
-                SKBitmap quantized = ArbitraryColourQuantizer.Quantize(source, (int)quantizerSettings.colourCount, quantizerSettings.useDithering ?? default, default);
+                SKBitmap quantized = ArbitraryColourQuantizer.Quantize(source, (int)quantizerSettings.colourCount, quantizerSettings.useDithering ?? default);
                 // need to make our palette now.
                 // Find all distinct colours in the image
                 var distinctColours = new HashSet<SKColor>();
-                // this could be better lol
-                for (int x = 0; x < quantized.Width; x++)
+                // this is slightly better than before
+                var span = MemoryMarshal.Cast<byte, SKColor>(quantized.GetPixelSpan());
+                foreach (var pixel in span)
                 {
-                    for (int y = 0; y < quantized.Height; y++)
-                    {
-                        var pixel = quantized.GetPixel(x, y);
-                        if (pixel.Alpha > 128)
-                            distinctColours.Add(pixel);
-                    }
+                    if (pixel.Alpha > 128)
+                        distinctColours.Add(pixel);
                 }
                 // make the PaletteColour's
                 var skToPalette  = new Dictionary<SKColor, PaletteColour>();

--- a/TomodachiDrawer.Core/ImageProcessing/Quantizers/ArbitraryColourQuantizer.cs
+++ b/TomodachiDrawer.Core/ImageProcessing/Quantizers/ArbitraryColourQuantizer.cs
@@ -59,7 +59,9 @@ namespace TomodachiDrawer.Core.ImageProcessing.Quantizers
                     for (int x = 0; x < image.Width; x++)
                     {
                         var p = row[x];
-                        pixels[y * image.Width + x] = new SKColor(p.R, p.G, p.B, p.A);
+                        pixels[y * image.Width + x] = p.A < 128
+                            ? SKColors.Transparent
+                            : new SKColor(p.R, p.G, p.B, 255);
                     }
                 }
             });

--- a/TomodachiDrawer.Core/ImageProcessing/Quantizers/ArbitraryColourQuantizer.cs
+++ b/TomodachiDrawer.Core/ImageProcessing/Quantizers/ArbitraryColourQuantizer.cs
@@ -1,259 +1,71 @@
 ﻿using SkiaSharp;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Quantization;
 
 namespace TomodachiDrawer.Core.ImageProcessing.Quantizers
 {
-    /// <summary>
-    /// This pisses me off to write, but this is not my code annoyingly.
-    /// I was trying to find some resources, but they all seemed suboptimal, or were literally 14 years old and probably sucked
-    /// and ran like ass. This was AI generated, and it annoys me. If theres a human made library out there that solves this problem
-    /// I am more than welcome to replacing this with that. For now, this is quarantined in here.
-    /// 
-    /// This particularly annoys me because I wanted .Core to be slop-free bweh
-    /// 
-    /// - Lucas7yoshi
-    /// </summary>
     public class ArbitraryColourQuantizer
     {
-        public static SKBitmap Quantize(SKBitmap input, int colourCount, bool useDithering = true, int maxIterations = 20)
+        public static SKBitmap Quantize(SKBitmap input, int colourCount, bool useDithering = true)
         {
             if (colourCount < 1) throw new ArgumentOutOfRangeException(nameof(colourCount), "Colour count must be at least 1.");
 
-            SKColor[] pixels = input.Pixels;
+            using var image = ToImageSharp(input);
 
-            // 1. Separate visible pixels from fully transparent pixels
-            // (If you want hard/binary edges without semi-transparency, change to `p.Alpha >= 128`)
-            SKColor[] visiblePixels = pixels.Where(p => p.Alpha > 0).ToArray();
-            bool hasTransparency = visiblePixels.Length < pixels.Length;
-
-            // If the image is entirely transparent, return immediately
-            if (visiblePixels.Length == 0) return input.Copy();
-
-            // 2. Adjust target colour count to accommodate the reserved Transparent slot
-            int k = hasTransparency ? colourCount - 1 : colourCount;
-
-            // Edge case: They requested exactly 1 colour, and the image has transparency.
-            // We must return a fully transparent image to stay within the 1-colour limit.
-            if (k <= 0)
+            var quantizer = new WuQuantizer(new QuantizerOptions
             {
-                SKBitmap empty = new SKBitmap(input.Info);
-                SKColor[] emptyPixels = new SKColor[pixels.Length];
-                Array.Fill(emptyPixels, SKColors.Transparent);
-                empty.Pixels = emptyPixels;
-                return empty;
-            }
+                MaxColors = colourCount,
+                Dither = useDithering ? KnownDitherings.FloydSteinberg : null
+            });
 
-            // 3. Initialize and run K-Means ONLY on the visible pixels
-            List<SKColor> palette = InitializeCentroidsKMeansPlusPlus(visiblePixels, k);
+            image.Mutate(x => x.Quantize(quantizer));
 
-            int[] assignments = new int[visiblePixels.Length];
-            bool changed = true;
-            int iteration = 0;
-
-            while (changed && iteration < maxIterations)
-            {
-                changed = false;
-                iteration++;
-
-                long[] rSum = new long[k];
-                long[] gSum = new long[k];
-                long[] bSum = new long[k];
-                long[] aSum = new long[k];
-                int[] counts = new int[k];
-
-                for (int i = 0; i < visiblePixels.Length; i++)
-                {
-                    int bestIndex = FindNearestColourIndex(visiblePixels[i], palette);
-
-                    if (assignments[i] != bestIndex)
-                    {
-                        assignments[i] = bestIndex;
-                        changed = true;
-                    }
-
-                    rSum[bestIndex] += visiblePixels[i].Red;
-                    gSum[bestIndex] += visiblePixels[i].Green;
-                    bSum[bestIndex] += visiblePixels[i].Blue;
-                    aSum[bestIndex] += visiblePixels[i].Alpha;
-                    counts[bestIndex]++;
-                }
-
-                for (int c = 0; c < k; c++)
-                {
-                    if (counts[c] > 0)
-                    {
-                        palette[c] = new SKColor(
-                            (byte)(rSum[c] / counts[c]),
-                            (byte)(gSum[c] / counts[c]),
-                            (byte)(bSum[c] / counts[c]),
-                            (byte)(aSum[c] / counts[c])
-                        );
-                    }
-                }
-            }
-
-            // 4. Map the original image back to the palette
-            SKColor[] resultPixels = new SKColor[pixels.Length];
-            int width = input.Width;
-            int height = input.Height;
-
-            float[]? rBuf = null, gBuf = null, bBuf = null, aBuf = null;
-            if (useDithering)
-            {
-                rBuf = pixels.Select(p => (float)p.Red).ToArray();
-                gBuf = pixels.Select(p => (float)p.Green).ToArray();
-                bBuf = pixels.Select(p => (float)p.Blue).ToArray();
-                aBuf = pixels.Select(p => (float)p.Alpha).ToArray();
-            }
-
-            for (int y = 0; y < height; y++)
-            {
-                for (int x = 0; x < width; x++)
-                {
-                    int idx = y * width + x;
-
-                    // --- STRICT TRANSPARENCY CHECK ---
-                    // If the original pixel was fully transparent, keep it fully transparent.
-                    // We check the ORIGINAL pixel, not the dither buffer, so bleeding error is ignored.
-                    if (pixels[idx].Alpha == 0)
-                    {
-                        resultPixels[idx] = SKColors.Transparent;
-                        continue; // Skip dithering error calculations entirely
-                    }
-
-                    if (!useDithering)
-                    {
-                        resultPixels[idx] = palette[FindNearestColourIndex(pixels[idx], palette)];
-                    }
-                    else if (rBuf != null && gBuf != null && bBuf != null && aBuf != null)
-                    {
-                        float r = Math.Clamp(rBuf[idx], 0f, 255f);
-                        float g = Math.Clamp(gBuf[idx], 0f, 255f);
-                        float b = Math.Clamp(bBuf[idx], 0f, 255f);
-                        float a = Math.Clamp(aBuf[idx], 0f, 255f);
-
-                        int bestIndex = FindNearestColourIndex(r, g, b, a, palette);
-                        SKColor newColour = palette[bestIndex];
-                        resultPixels[idx] = newColour;
-
-                        float errR = r - newColour.Red;
-                        float errG = g - newColour.Green;
-                        float errB = b - newColour.Blue;
-                        float errA = a - newColour.Alpha;
-
-                        DistributeError(rBuf, gBuf, bBuf, aBuf, x + 1, y, width, height, errR, errG, errB, errA, 7f / 16f);
-                        DistributeError(rBuf, gBuf, bBuf, aBuf, x - 1, y + 1, width, height, errR, errG, errB, errA, 3f / 16f);
-                        DistributeError(rBuf, gBuf, bBuf, aBuf, x, y + 1, width, height, errR, errG, errB, errA, 5f / 16f);
-                        DistributeError(rBuf, gBuf, bBuf, aBuf, x + 1, y + 1, width, height, errR, errG, errB, errA, 1f / 16f);
-                    }
-                    else
-                        throw new Exception("This should never be hit, the previous if stuff is to silence some warnings.");
-                }
-            }
-
-            SKBitmap result = new SKBitmap(input.Info);
-            result.Pixels = resultPixels;
-            return result;
+            return ToSkBitmap(image);
         }
 
-        private static List<SKColor> InitializeCentroidsKMeansPlusPlus(SKColor[] pixels, int k)
+        private static Image<Rgba32> ToImageSharp(SKBitmap bitmap)
         {
-            var centroids = new List<SKColor>(k);
-            var random = new Random();
+            var image = new Image<Rgba32>(bitmap.Width, bitmap.Height);
+            var pixels = bitmap.Pixels;
 
-            centroids.Add(pixels[random.Next(pixels.Length)]);
-
-            long[] distances = new long[pixels.Length];
-            Array.Fill(distances, long.MaxValue);
-
-            for (int i = 1; i < k; i++)
+            image.ProcessPixelRows(accessor =>
             {
-                long totalDistance = 0;
-                SKColor lastCentroid = centroids[i - 1];
-
-                for (int p = 0; p < pixels.Length; p++)
+                for (int y = 0; y < bitmap.Height; y++)
                 {
-                    long dist = ColourDistance(pixels[p], lastCentroid);
-                    if (dist < distances[p]) distances[p] = dist;
-                    totalDistance += distances[p];
-                }
-
-                long randomValue = (long)(random.NextDouble() * totalDistance);
-                long runningSum = 0;
-
-                for (int p = 0; p < pixels.Length; p++)
-                {
-                    runningSum += distances[p];
-                    if (runningSum >= randomValue)
+                    var row = accessor.GetRowSpan(y);
+                    for (int x = 0; x < bitmap.Width; x++)
                     {
-                        centroids.Add(pixels[p]);
-                        break;
+                        var p = pixels[y * bitmap.Width + x];
+                        row[x] = new Rgba32(p.Red, p.Green, p.Blue, p.Alpha);
                     }
                 }
-            }
+            });
 
-            return centroids;
+            return image;
         }
 
-        private static int FindNearestColourIndex(SKColor target, List<SKColor> palette)
+        private static SKBitmap ToSkBitmap(Image<Rgba32> image)
         {
-            int bestIdx = 0;
-            long bestDist = long.MaxValue;
+            var bitmap = new SKBitmap(image.Width, image.Height);
+            var pixels = new SKColor[image.Width * image.Height];
 
-            for (int i = 0; i < palette.Count; i++)
+            image.ProcessPixelRows(accessor =>
             {
-                long dist = ColourDistance(target, palette[i]);
-                if (dist < bestDist)
+                for (int y = 0; y < image.Height; y++)
                 {
-                    bestDist = dist;
-                    bestIdx = i;
+                    var row = accessor.GetRowSpan(y);
+                    for (int x = 0; x < image.Width; x++)
+                    {
+                        var p = row[x];
+                        pixels[y * image.Width + x] = new SKColor(p.R, p.G, p.B, p.A);
+                    }
                 }
-            }
-            return bestIdx;
-        }
+            });
 
-        private static int FindNearestColourIndex(float r, float g, float b, float a, List<SKColor> palette)
-        {
-            int bestIdx = 0;
-            float bestDist = float.MaxValue;
-
-            for (int i = 0; i < palette.Count; i++)
-            {
-                float dr = r - palette[i].Red;
-                float dg = g - palette[i].Green;
-                float db = b - palette[i].Blue;
-                float da = a - palette[i].Alpha;
-
-                float dist = (dr * dr * 3) + (dg * dg * 4) + (db * db * 2) + (da * da);
-                if (dist < bestDist)
-                {
-                    bestDist = dist;
-                    bestIdx = i;
-                }
-            }
-            return bestIdx;
-        }
-
-        private static long ColourDistance(SKColor c1, SKColor c2)
-        {
-            long dr = c1.Red - c2.Red;
-            long dg = c1.Green - c2.Green;
-            long db = c1.Blue - c2.Blue;
-            long da = c1.Alpha - c2.Alpha;
-
-            return (dr * dr * 3) + (dg * dg * 4) + (db * db * 2) + (da * da);
-        }
-
-        private static void DistributeError(float[] rBuf, float[] gBuf, float[] bBuf, float[] aBuf,
-                                            int x, int y, int width, int height,
-                                            float errR, float errG, float errB, float errA, float weight)
-        {
-            if (x < 0 || x >= width || y < 0 || y >= height) return;
-
-            int idx = y * width + x;
-            rBuf[idx] += errR * weight;
-            gBuf[idx] += errG * weight;
-            bBuf[idx] += errB * weight;
-            aBuf[idx] += errA * weight;
+            bitmap.Pixels = pixels;
+            return bitmap;
         }
     }
 }

--- a/TomodachiDrawer.Core/TomodachiDrawer.Core.csproj
+++ b/TomodachiDrawer.Core/TomodachiDrawer.Core.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.OrTools" Version="9.15.6755" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What's been done

- `feat:` replaced "ai slop" with human written library
- `refactor:` improve palette calculation
- `chore:` added `.idea` to `.gitignore`

## Demo

#### Target image <sup>[the best album of all time](https://open.spotify.com/album/18hrkvndprWjt9olhQlRcH)</sup>
<img width="256" height="256" alt="zeros_declan mckenna-1" src="https://github.com/user-attachments/assets/a9d8ab0b-0093-4651-9f7a-51b81a0ccd4a" />

| Colours | Before | After |
| -- | -- | -- |
| 16 | <img width="1312" height="825" alt="TomodachiDrawer UI Avalonia_LCsVaalVpq" src="https://github.com/user-attachments/assets/ada45147-4796-4100-a6d4-c2266e75e6ca" /> | <img width="1312" height="825" alt="TomodachiDrawer UI Avalonia_yGYHr2KzZu" src="https://github.com/user-attachments/assets/80d1ceb5-956e-470e-b93c-b94fc113dd2d" /> |
| 32 | <img width="1312" height="825" alt="TomodachiDrawer UI Avalonia_Zl1TS0zo2x" src="https://github.com/user-attachments/assets/e4e144b4-3ba8-45f9-963f-2a8fbef895bd" /> | <img width="1312" height="825" alt="TomodachiDrawer UI Avalonia_DUZhCC09QD" src="https://github.com/user-attachments/assets/9c265215-32c8-4206-82f2-ff5ee518d9f6" />  |
| 64 | <img width="1312" height="825" alt="TomodachiDrawer UI Avalonia_up7gx0C59M" src="https://github.com/user-attachments/assets/ecc47293-e9c5-4426-86ef-10904c400f61" /> | <img width="1312" height="825" alt="TomodachiDrawer UI Avalonia_HRv8cdsBJF" src="https://github.com/user-attachments/assets/baa229c8-c4b1-457b-bccf-583a465055f8" /> |

## Notes

This is an awesome project! Would love to see an API server + web UI for it, that may be my next contribution!
