### PR TITLE
Add flag to reverse the order in which the colour layers are drawn

### DIFF
--- a/TomodachiDrawer.Core/CanvasDrawer.cs
+++ b/TomodachiDrawer.Core/CanvasDrawer.cs
@@ -114,6 +114,7 @@ namespace TomodachiDrawer.Core
             // The dynamic bucket fill on the other hand is prone to desyncs even on switch 2, thus is classified as experimental.
             if (
                 _switchVersion == SwitchVersion.Switch2
+                && !settings.ReverseLayerOrder
                 && image.Width == 256
                 && image.Height == 256
             )
@@ -192,11 +193,24 @@ namespace TomodachiDrawer.Core
 
             var totalLayers = layers.Count;
             // 80% divided by total layers.
-            int layerNumber = 0;
-            foreach (var l in layers)
-            {
-                layerNumber++;
 
+            if (!settings.ReverseLayerOrder)
+            {
+                for (int layerNumber = 0; layerNumber < layers.Count; layerNumber++)
+                {
+                    DrawLayer(layers[layerNumber], layerNumber);
+                }
+            }
+            else
+            {
+                for (int layerNumber = layers.Count - 1; layerNumber >= 0; layerNumber--)
+                {
+                    DrawLayer(layers[layerNumber], layerNumber);
+                }
+            }
+
+            void DrawLayer(ColourLayer l, int layerNumber)
+            {
                 _palette.SelectColour(l.Colour, 25.0);
 
                 // STAMPS
@@ -309,6 +323,7 @@ namespace TomodachiDrawer.Core
                     }
                 }
             }
+
             _log(
                 $"Done! Total in layer draw time: {totalInLayerTime:F3}s (Doesnt include colour/brush selection)"
             );

--- a/TomodachiDrawer.Core/Models/DrawImageSettings.cs
+++ b/TomodachiDrawer.Core/Models/DrawImageSettings.cs
@@ -15,5 +15,8 @@ namespace TomodachiDrawer.Core.Models
 
         /// <summary>Enables stuff that may be prone to desyncs or other instabilities.</summary>
         public bool EnableExperimentalFeatures { get; set; } = false;
+
+        /// <summary>Draw layers in reverse order. Helpful when restarting a drawing that was almost complete.</summary>
+        public bool ReverseLayerOrder { get; set; } = false;
     }
 }

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
@@ -117,6 +117,9 @@
 								<ComboBoxItem>Switch 2</ComboBoxItem>
 							</ComboBox>
 						</Grid>
+						<CheckBox x:Name="ReverseLayerOrderCheckBox"
+								  Content="Draw Colors In Reverse"
+								  />
 						<CheckBox x:Name="EnableExperimentalCheckBox"
 								  Content="Enable Experimental (Possibly Desync Prone) Features"
 								  IsCheckedChanged="EnableExperimentalCheckBox_IsCheckedChanged"

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
@@ -118,7 +118,7 @@
 							</ComboBox>
 						</Grid>
 						<CheckBox x:Name="ReverseLayerOrderCheckBox"
-								  Content="Draw Colors In Reverse"
+								  Content="Draw Colours In Reverse"
 								  />
 						<CheckBox x:Name="EnableExperimentalCheckBox"
 								  Content="Enable Experimental (Possibly Desync Prone) Features"

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -559,6 +559,7 @@ public partial class MainWindow : Window
         BusyExporting = true;
         TimeSpan totalTime = TimeSpan.MaxValue;
         var settings = GetQuantizerSettings();
+        var reverseLayerOrder = ReverseLayerOrderCheckBox.IsChecked ?? false;
         var enableExperimental = EnableExperimentalCheckBox.IsChecked ?? false;
 
         await Task.Run(async () =>
@@ -583,6 +584,7 @@ public partial class MainWindow : Window
                 DenoiserName = denoiser,
                 TSPTimeLimit = tspLimit,
                 DisableLargeBrush = false,
+                ReverseLayerOrder = reverseLayerOrder,
                 EnableExperimentalFeatures = enableExperimental,
             };
             await drawer.DrawImage(SKBitmap.Decode(imagePath), drawSettings);


### PR DESCRIPTION
I added this because one of my drawings was interrupted by the game update dialog with 80% of it done...

Thought someone else might find it helpful 🙂.

<img width="1102" height="792" alt="" src="https://github.com/user-attachments/assets/28970f5f-4dac-4d97-b5b4-cbbed0986717" />

One little quirk is that the logs now count down instead of up. I felt like that was okay to have, because it tells you the flag is working as intended.