### PR TITLE
Prevent crash caused by permission issues

### DIFF
--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -185,6 +185,45 @@ public partial class MainWindow : Window
         base.OnClosed(e);
     }
 
+    // Check if we can access the RP2040 drive.
+    // Also trigger permission prompt on macOS if we haven't been granted permissions yet.
+    // Returns `true` if we can access it.
+    private bool CanAccessRP2040Drive(string drivePath)
+    {
+        try
+        {
+            // Try to access the drive by listing its files.
+            // This also trigger the permission prompt on macOS.
+            _ = Directory.GetFiles(drivePath);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // macOS: User (probably) clicked "Don't Allow".
+            if (OperatingSystem.IsMacOS())
+            {
+                _ = ShowMessageAsync(
+                    "Permission Denied",
+                    $"Permission to access the RPI-RP2 drive ({drivePath}) was denied.\n\n"
+                        + "Please open System Settings -> Privacy & Security -> Files & Folders, find \"TomodachiDrawer\", and make sure \"Removable Volumes\" is enabled.\n\n"
+                        + "This is required for the app to write the firmware directly to your RPI-RP2 drive.\r"
+                        + $"Or you can manually copy the .uf2 file to {drivePath} if you want to avoid granting permissions.",
+                    new Uri("x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders"),
+                    "Open System Settings"
+                );
+            }
+            // Log the error. Just in case, log on other OSes as well.
+            AppendLog($"Permission to access RPI-RP2 drive ({drivePath}) was denied");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // Also just in case, log any other error that might occur while trying to access the drive.
+            AppendLog($"Could not access the RPI-RP2 drive ({drivePath}): {ex.Message}");
+            return false;
+        }
+    }
+
     // ── RP2040 polling ────────────────────────────────────────────────
 
     private void StartRP2040Polling()
@@ -536,7 +575,7 @@ public partial class MainWindow : Window
             var uf2Bytes = UF2Flasher.BuildTDLDUF2(tdldBytes);
             var drivePath = UF2Flasher.FindRP2040Drive();
 
-            if (uf2Bytes != null && uf2Bytes.Length > 0 && drivePath != null)
+            if (uf2Bytes != null && uf2Bytes.Length > 0 && drivePath != null && CanAccessRP2040Drive(drivePath))
             {
                 File.WriteAllBytes(Path.Combine(drivePath, "tdld_image.uf2"), uf2Bytes);
                 AppendLog(
@@ -693,6 +732,10 @@ public partial class MainWindow : Window
         if (drivePath == null)
         {
             _ = ShowMessageAsync("Error", "RP2040 not detected. Connect it in BOOT mode first.");
+            return;
+        }
+        if (!CanAccessRP2040Drive(drivePath))
+        {
             return;
         }
 

--- a/TomodachiDrawer.UI.Avalonia/Packaging/macOS/Info.plist
+++ b/TomodachiDrawer.UI.Avalonia/Packaging/macOS/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>{{version}}</string>
     <key>NSRemovableVolumesUsageDescription</key>
-    <string>This app needs access to removable volumes to flash the firmware to your RP2040 microcontroller.</string>
+    <string>This app needs access to removable volumes to flash the firmware or image data directly to your microcontroller.</string>
 </dict>
 </plist>

--- a/TomodachiDrawer.UI.Avalonia/Packaging/macOS/Info.plist
+++ b/TomodachiDrawer.UI.Avalonia/Packaging/macOS/Info.plist
@@ -18,5 +18,7 @@
 	<string>{{version}}</string>
 	<key>CFBundleShortVersionString</key>
 	<string>{{version}}</string>
+    <key>NSRemovableVolumesUsageDescription</key>
+    <string>This app needs access to removable volumes to flash the firmware to your RP2040 microcontroller.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request adds a permission check before writing to the RPI-RP2 drive.

I added a method called `CanAccessRP2040Drive` that checks if the app has permission to access the RPI-RP2 drive by attempting to list its files using the `Directory.GetFiles`. Returns `true` if the app can access the drive. On macOS, this also automatically trigger the permission prompt.

If `UnauthorizedAccessException` is caught, the error is logged without crashing the entire app. On macOS, this message box will also be displayed.

<img width="552" height="399" alt="Screenshot 2026-05-21 at 21 30 36" src="https://github.com/user-attachments/assets/130b1328-6eaf-42c6-8dd4-655b89cab251" />

The "Open System Settings" button simply redirects the user to the "Privacy & Security > Files & Folders" setting.

The permission prompt also informs why the app needs access to files on a removable volume too!

<img width="372" height="394" alt="Screenshot 2026-05-21 at 21 30 28" src="https://github.com/user-attachments/assets/30df33d5-e6fa-4a25-822e-1de8cb788ca4" />

Should fix #56 :)