### PR TITLE
Completely optional and opt-in telemetry.

### DIFF
--- a/TomodachiDrawer.Core/Models/ColourLayer.cs
+++ b/TomodachiDrawer.Core/Models/ColourLayer.cs
@@ -19,9 +19,9 @@ namespace TomodachiDrawer.Core.Models
         public Dictionary<int, List<CanvasPoint>> StampsBySize = new();
 
         /// <summary>1x1 points for individual drawing.</summary>
-        public HashSet<CanvasPoint> FineDetailPoints = new();
+        public HashSet<CanvasPoint> FineDetailPoints = [];
 
         /// <summary>Interior points to click with the bucket tool after drawing the outline.</summary>
-        public HashSet<CanvasPoint> BucketClicks = new();
+        public HashSet<CanvasPoint> BucketClicks = [];
     }
 }

--- a/TomodachiDrawer.UI.Avalonia/AppSettings.cs
+++ b/TomodachiDrawer.UI.Avalonia/AppSettings.cs
@@ -14,6 +14,9 @@ internal class AppSettings
     public bool CheckForUpdatesOnStart { get; set; } = true;
 
     public int FirstStartId { get; set; } = 0;
+
+    /// <summary>This is null by default to indicate they havent been asked yet.</summary>
+    public bool? EnableTelemetry { get; set; } = null;
 }
 
 // Source gen serialization to avoid trimming warnings.

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
@@ -43,6 +43,11 @@
 					ToggleType="CheckBox"
 					Click="EnableExperimentalMenuItem_Click"
 				/>
+				<MenuItem
+					x:Name="OpenTelemetryPrompt"
+					Header="_Open Telemetry Prompt"
+					Click="OpenTelemetryPrompt_Click"
+				/>
 			</MenuItem>
 			<MenuItem Header="_Templates" x:Name="MenuTemplates">
 				<!-- Inserted at runtime -->

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -702,7 +702,7 @@ public partial class MainWindow : Window
         _ = _telemetry.ReportImage(new TelemetryService.ImageEventDto(
             imageWidth, imageHeight, colourCount, quantizerName, colourLimit,
             _currentSettings.SelectedSwitchVersion.ToString(),
-            enableExperimental, totalTime.TotalSeconds
+            enableExperimental, totalTime.TotalSeconds, tspLimit
         ));
 
         BusyExporting = false;
@@ -862,7 +862,7 @@ public partial class MainWindow : Window
         _ = _telemetry.ReportImage(new TelemetryService.ImageEventDto(
             imageWidth, imageHeight, colourCount, quantizerName, colourLimit,
             _currentSettings.SelectedSwitchVersion.ToString(),
-            enableExperimental, totalTime.TotalSeconds
+            enableExperimental, totalTime.TotalSeconds, tspLimit
         ));
 
         ExportUF2Button.IsEnabled = true;

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -156,13 +156,21 @@ public partial class MainWindow : Window
     {
         if (_currentSettings.FirstStartId != CURRENT_WELCOME_ID)
         {
-            ShowWelcomeMessage();
+            await ShowWelcomeMessage();
             _currentSettings.FirstStartId = CURRENT_WELCOME_ID;
         }
 
 #if DEBUG
         InsertDebugMenuItems();
 #endif
+
+        if (_currentSettings.EnableTelemetry == null)
+        {
+            // User hasnt agreed/disagreed.
+            var accepted = await new TelemetryPrompt().ShowDialog<bool>(this);
+            _currentSettings.EnableTelemetry = accepted;
+        }
+
         SaveSettings();
 
         if (!IsVCRuntimeInstalled())
@@ -181,7 +189,7 @@ public partial class MainWindow : Window
     // Welcome message stuff. For important changes, the ID is incremented by one by hand whenever something notable changes.
     // This is only really needed for Mac since its settings are saved in a way that persists more readily.
     private const int CURRENT_WELCOME_ID = 2;
-    private async void ShowWelcomeMessage()
+    private async Task ShowWelcomeMessage()
     {
         await ShowMessageAsync(
             "Welcome to TomodachiDrawer",
@@ -1231,5 +1239,12 @@ public partial class MainWindow : Window
     private void EnableHomeCanvas_IsCheckedChanged(object? sender, RoutedEventArgs e)
     {
         // TODO: Notify if non 256x256 image.
+    }
+
+    private async void OpenTelemetryPrompt_Click(object? sender, RoutedEventArgs e)
+    {
+        var answer = await new TelemetryPrompt().ShowDialog<bool>(this);
+        _currentSettings.EnableTelemetry = answer;
+        SaveSettings();
     }
 }

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -668,11 +668,64 @@ public partial class MainWindow : Window
             return;
         }
 
+        var colourCount = CountDistinctColours(_currentImage);
+        var imageWidth = _currentImage.Width;
+        var imageHeight = _currentImage.Height;
         var imageSnapshot = _currentImage!.Copy();
-        var drawSettings = GetDrawImageSettings();
+        var denoiser = DenoisingComboBox.SelectedItem?.ToString();
+        var tspLimit = (float)(TSPTimeLimitUpDown.Value ?? 0.5m);
+        var settings = GetQuantizerSettings();
+        var enableExperimental = EnableExperimentalMenuItem.IsChecked;
+        var enableHome = EnableHomeCanvas.IsChecked ?? false;
+        string quantizerName = ColourMatcherComboBox.SelectedItem!.ToString()!;
+        int? colourLimit = quantizerName == "Arbitrary" ? (int)(ColourLimitUpDown.Value ?? 32) : (int?)null;
 
         BusyExporting = true;
         ExportRP2040Button.IsEnabled = false;
+
+        var (uf2Bytes, totalTime) = await GenerateUF2Async(
+            imageSnapshot, settings, denoiser, tspLimit, enableExperimental, enableHome,
+            "Exporting to RP2040 flash");
+
+        if (uf2Bytes != null && uf2Bytes.Length > 0)
+        {
+            var drivePath = UF2Flasher.FindRP2040Drive();
+            if (drivePath != null && CanAccessRP2040Drive(drivePath))
+            {
+                File.WriteAllBytes(Path.Combine(drivePath, "tdld_image.uf2"), uf2Bytes);
+                AppendLog(
+                    "Wrote to RP2040 flash. Unplug the RP2040 and plug it into the switch without holding any button."
+                );
+            }
+        }
+
+        _ = _telemetry.ReportImage(new TelemetryService.ImageEventDto(
+            imageWidth, imageHeight, colourCount, quantizerName, colourLimit,
+            _currentSettings.SelectedSwitchVersion.ToString(),
+            enableExperimental, totalTime.TotalSeconds
+        ));
+
+        BusyExporting = false;
+        ExportRP2040Button.IsEnabled = true;
+        SetEstimate(totalTime);
+    }
+
+    private void SetEstimate(TimeSpan time)
+    {
+        var estimateStr = $"{time:h\\hm\\ms\\s}";
+        DrawTimeLabel.Text = $"Draw Time Estimate: {estimateStr}";
+    }
+
+    private async Task<(byte[]? uf2Bytes, TimeSpan totalTime)> GenerateUF2Async(
+        SKBitmap imageSnapshot,
+        QuantizerSettings settings,
+        string? denoiser,
+        float tspLimit,
+        bool enableExperimental,
+        bool homeToTopLeft,
+        string logPrefix)
+    {
+        byte[]? uf2Bytes = null;
         TimeSpan totalTime = TimeSpan.MaxValue;
 
         await Task.Run(async () =>
@@ -683,7 +736,7 @@ public partial class MainWindow : Window
                 $"rp2040output{System.Random.Shared.Next(1000000, 9999999)}.tdld"
             );
 
-            AppendLog($"Exporting to RP2040 flash ({Path.GetFileName(tempPath)})");
+            AppendLog($"{logPrefix} ({Path.GetFileName(tempPath)})");
             var timingSink = new TimingSink();
             var drawer = new CanvasDrawer(
                 timingSink,
@@ -692,6 +745,15 @@ public partial class MainWindow : Window
             );
             drawer.ConnectAndConfirmController();
             AppendLog("Starting to generate inputs...");
+            var drawSettings = new DrawImageSettings()
+            {
+                QuantizerSettings = settings,
+                DenoiserName = denoiser,
+                TSPTimeLimit = tspLimit,
+                DisableLargeBrush = false,
+                EnableExperimentalFeatures = enableExperimental,
+                HomeToTopLeft = homeToTopLeft,
+            };
             await drawer.DrawImage(img, drawSettings);
             AppendLog($"True complete overall time is: {timingSink.TotalTime.TotalSeconds}s");
 
@@ -700,16 +762,7 @@ public partial class MainWindow : Window
             fileSink.Dispose();
 
             var tdldBytes = File.ReadAllBytes(tempPath);
-            var uf2Bytes = UF2Flasher.BuildTDLDUF2(tdldBytes);
-            var drivePath = UF2Flasher.FindRP2040Drive();
-
-            if (uf2Bytes != null && uf2Bytes.Length > 0 && drivePath != null && CanAccessRP2040Drive(drivePath))
-            {
-                File.WriteAllBytes(Path.Combine(drivePath, "tdld_image.uf2"), uf2Bytes);
-                AppendLog(
-                    "Wrote to RP2040 flash. Unplug the RP2040 and plug it into the switch without holding any button."
-                );
-            }
+            uf2Bytes = UF2Flasher.BuildTDLDUF2(tdldBytes);
 
 #if !DEBUG
             if (File.Exists(tempPath))
@@ -718,10 +771,7 @@ public partial class MainWindow : Window
             totalTime = timingSink.TotalTime;
         });
 
-        BusyExporting = false;
-        ExportRP2040Button.IsEnabled = true;
-
-        SetEstimate(totalTime);
+        return (uf2Bytes, totalTime);
     }
 
     private DrawImageSettings GetDrawImageSettings()
@@ -743,10 +793,13 @@ public partial class MainWindow : Window
         };
     }
 
-    private void SetEstimate(TimeSpan time)
+    private static int CountDistinctColours(SKBitmap img)
     {
-        var estimateStr = $"{time:h\\hm\\ms\\s}";
-        DrawTimeLabel.Text = $"Draw Time Estimate: {estimateStr}";
+        var pixels = new HashSet<SKColor>();
+        for (int y = 0; y < img.Height; y++)
+            for (int x = 0; x < img.Width; x++)
+                pixels.Add(img.GetPixel(x, y));
+        return pixels.Count;
     }
 
     private async void ExportUF2Button_Click(object sender, RoutedEventArgs e)
@@ -782,55 +835,38 @@ public partial class MainWindow : Window
         if (outputPath == null)
             return;
 
+        var colourCount = CountDistinctColours(_currentImage);
+        var imageWidth = _currentImage.Width;
+        var imageHeight = _currentImage.Height;
         var imageSnapshot = _currentImage!.Copy();
-        var drawSettings = GetDrawImageSettings();
+        var denoiser = DenoisingComboBox.SelectedItem?.ToString();
+        var tspLimit = (float)(TSPTimeLimitUpDown.Value ?? 0.5m);
+        var settings = GetQuantizerSettings();
+        var enableExperimental = EnableExperimentalMenuItem.IsChecked;
+        string quantizerName = ColourMatcherComboBox.SelectedItem!.ToString()!;
+        int? colourLimit = quantizerName == "Arbitrary" ? (int)(ColourLimitUpDown.Value ?? 32) : (int?)null;
 
         ExportUF2Button.IsEnabled = false;
         BusyExporting = true;
-        TimeSpan totalTime = TimeSpan.MaxValue;
 
-        await Task.Run(async () =>
+        var (uf2Bytes, totalTime) = await GenerateUF2Async(
+            imageSnapshot, settings, denoiser, tspLimit, enableExperimental, false,
+            "Exporting to UF2");
+
+        if (uf2Bytes != null && uf2Bytes.Length > 0)
         {
-            using var img = imageSnapshot;
-            string tempPath = Path.Combine(
-                Path.GetTempPath(),
-                $"rp2040output{System.Random.Shared.Next(1000000, 9999999)}.tdld"
-            );
+            File.WriteAllBytes(outputPath, uf2Bytes);
+            AppendLog($"Saved UF2 to {outputPath}");
+        }
 
-            AppendLog($"Exporting to UF2 ({Path.GetFileName(tempPath)})");
-            var timingSink = new TimingSink();
-            var drawer = new CanvasDrawer(
-                timingSink,
-                _currentSettings.SelectedSwitchVersion,
-                AppendLog
-            );
-            drawer.ConnectAndConfirmController();
-            AppendLog("Starting to generate inputs...");
-            await drawer.DrawImage(img, drawSettings);
-            AppendLog($"True complete overall time is: {timingSink.TotalTime.TotalSeconds}s");
-
-            var fileSink = new FileControllerSink(tempPath);
-            timingSink.ReplayTo(fileSink);
-            fileSink.Dispose();
-
-            var tdldBytes = File.ReadAllBytes(tempPath);
-            var uf2Bytes = UF2Flasher.BuildTDLDUF2(tdldBytes);
-
-            if (uf2Bytes != null && uf2Bytes.Length > 0)
-            {
-                File.WriteAllBytes(outputPath, uf2Bytes);
-                AppendLog($"Saved UF2 to {outputPath}");
-            }
-#if !DEBUG
-            if (File.Exists(tempPath))
-                File.Delete(tempPath);
-#endif
-            totalTime = timingSink.TotalTime;
-        });
+        _ = _telemetry.ReportImage(new TelemetryService.ImageEventDto(
+            imageWidth, imageHeight, colourCount, quantizerName, colourLimit,
+            _currentSettings.SelectedSwitchVersion.ToString(),
+            enableExperimental, totalTime.TotalSeconds
+        ));
 
         ExportUF2Button.IsEnabled = true;
         BusyExporting = false;
-
         SetEstimate(totalTime);
     }
 

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -38,6 +38,7 @@ public partial class MainWindow : Window
     private string _currentImagePath = string.Empty;
     private SKBitmap? _currentImage;
     private readonly CancellationTokenSource _cts = new();
+    private TelemetryService _telemetry;
 
     private bool BusyExporting = false;
 
@@ -87,9 +88,9 @@ public partial class MainWindow : Window
         if (CheckForUpdatesCheckBox.IsChecked)
             _ = PerformAsyncUpdateCheck();
 
+        _telemetry = new TelemetryService();
+
         Opened += MainWindow_Opened;
-
-
     }
 
     private bool IsVCRuntimeInstalled()
@@ -183,6 +184,13 @@ public partial class MainWindow : Window
                 new Uri("https://aka.ms/vc14/vc_redist.x64.exe"),
                 "Download Redistributable"
             );
+        }
+
+        if (_currentSettings.EnableTelemetry == true)
+        {
+            _telemetry.TelemetryEnabled = true;
+            // Discard to avoid blocking.
+            _ = _telemetry.ReportStart();
         }
     }
 
@@ -1232,7 +1240,7 @@ public partial class MainWindow : Window
         Close();
     }
 
-    private void MenuHelpOpenWelcome_Click(object? sender, RoutedEventArgs e) => ShowWelcomeMessage();
+    private async void MenuHelpOpenWelcome_Click(object? sender, RoutedEventArgs e) => await ShowWelcomeMessage();
 
     private void MenuHelpCheckForUpdate_Click(object? sender, RoutedEventArgs e) => _ = PerformAsyncUpdateCheck();
 
@@ -1245,6 +1253,7 @@ public partial class MainWindow : Window
     {
         var answer = await new TelemetryPrompt().ShowDialog<bool>(this);
         _currentSettings.EnableTelemetry = answer;
+        _telemetry.TelemetryEnabled = answer;
         SaveSettings();
     }
 }

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -699,7 +699,7 @@ public partial class MainWindow : Window
             }
         }
 
-        _ = _telemetry.ReportImage(new TelemetryService.ImageEventDto(
+        _ = _telemetry.ReportImage(new ImageEventDto(
             imageWidth, imageHeight, colourCount, quantizerName, colourLimit,
             _currentSettings.SelectedSwitchVersion.ToString(),
             enableExperimental, totalTime.TotalSeconds, tspLimit
@@ -859,7 +859,7 @@ public partial class MainWindow : Window
             AppendLog($"Saved UF2 to {outputPath}");
         }
 
-        _ = _telemetry.ReportImage(new TelemetryService.ImageEventDto(
+        _ = _telemetry.ReportImage(new ImageEventDto(
             imageWidth, imageHeight, colourCount, quantizerName, colourLimit,
             _currentSettings.SelectedSwitchVersion.ToString(),
             enableExperimental, totalTime.TotalSeconds, tspLimit

--- a/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
@@ -27,6 +27,7 @@
 				<TextBlock Text="  - Selected Switch version" />
 				<TextBlock Text="  - Whether experimental features are enabled" />
 				<TextBlock Text="  - Draw time estimate" />
+				<TextBlock Text="  - TSP Time Limit" />
 			</StackPanel>
 		</Expander>
 

--- a/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
@@ -1,0 +1,53 @@
+<Window xmlns="https://github.com/avaloniaui"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		x:Class="TomodachiDrawer.UI.Avalonia.TelemetryPrompt"
+		Title="Telemetry Opt-In"
+		Width="420" Height="440"
+		MinWidth="420" MinHeight="440"
+		CanResize="False"
+		WindowStartupLocation="CenterOwner">
+
+	<StackPanel Margin="16" Spacing="12">
+		<TextBlock FontWeight="SemiBold" FontSize="15" Text="Help improve Tomodachi Drawer?" />
+		<TextBlock TextWrapping="Wrap"
+				   Text="Anonymous usage data helps me to better understand how the app is used and know where to focus development efforts. No personal data is collected."
+				   />
+
+		<Border BorderBrush="#55888888" BorderThickness="2" CornerRadius="4" Padding="8">
+			<StackPanel Spacing="2">
+				<TextBlock FontWeight="SemiBold" Text="On startup:" />
+				<TextBlock Text="  - Operating system and version" />
+				<TextBlock Text="  - CPU architecture" />
+				<TextBlock Text="  - App version" />
+				<TextBlock FontWeight="SemiBold" Margin="0,4,0,0" Text="When an image is processed:" />
+				<TextBlock Text="  - Image dimensions" />
+				<TextBlock Text="  - Number of colours in the image" />
+				<TextBlock Text="  - Colour quantizer mode and limit" />
+				<TextBlock Text="  - Selected Switch version" />
+				<TextBlock Text="  - Whether experimental features are enabled" />
+			</StackPanel>
+		</Border>
+
+		<TextBlock 
+				FontWeight="Bold" TextDecorations="Underline" 
+				Text="Your actual images are never uploaded." 
+				/>
+		<TextBlock FontStyle="Italic" Text="You can change your mind later through the Settings toolbar."/>
+
+		<StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+			<Button x:Name="SureButton" FontWeight="SemiBold" Click="SureButton_Click"
+					Background="#2E7D32" Foreground="White">
+				<TextBlock 
+						FontWeight="SemiBold"
+						Text="Sure"
+						TextDecorations="Underline"
+					/>
+			</Button>
+			<Button x:Name="NoThanksButton" Content="No Thanks" Click="NoThanksButton_Click"
+					Background="#C62828" Foreground="White" />
+			<Button x:Name="OpenSourceButton" Content="View Telemetry Source Code" Click="OpenSourceButton_Click"
+					Background="#1565C0" Foreground="White" />
+		</StackPanel>
+	</StackPanel>
+
+</Window>

--- a/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
@@ -2,9 +2,10 @@
 		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		x:Class="TomodachiDrawer.UI.Avalonia.TelemetryPrompt"
 		Title="Telemetry Opt-In"
-		Width="420" Height="440"
-		MinWidth="420" MinHeight="440"
+		Width="420"
+		MinWidth="420" MinHeight="240"
 		CanResize="False"
+		SizeToContent="Height"
 		WindowStartupLocation="CenterOwner">
 
 	<StackPanel Margin="16" Spacing="12">
@@ -13,26 +14,27 @@
 				   Text="Anonymous usage data helps me to better understand how the app is used and know where to focus development efforts. No personal data is collected."
 				   />
 
-		<Border BorderBrush="#55888888" BorderThickness="2" CornerRadius="4" Padding="8">
-			<StackPanel Spacing="2">
+		<Expander Header="What's collected?" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+			<StackPanel Spacing="2" Margin="4,4,0,4">
 				<TextBlock FontWeight="SemiBold" Text="On startup:" />
 				<TextBlock Text="  - Operating system and version" />
 				<TextBlock Text="  - CPU architecture" />
 				<TextBlock Text="  - App version" />
-				<TextBlock FontWeight="SemiBold" Margin="0,4,0,0" Text="When an image is processed:" />
+				<TextBlock FontWeight="SemiBold" Margin="0,4,0,0" Text="When an image is exported:" />
 				<TextBlock Text="  - Image dimensions" />
 				<TextBlock Text="  - Number of colours in the image" />
 				<TextBlock Text="  - Colour quantizer mode and limit" />
 				<TextBlock Text="  - Selected Switch version" />
 				<TextBlock Text="  - Whether experimental features are enabled" />
+				<TextBlock Text="  - Draw time estimate" />
 			</StackPanel>
-		</Border>
+		</Expander>
 
 		<TextBlock 
 				FontWeight="Bold" TextDecorations="Underline" 
 				Text="Your actual images are never uploaded." 
 				/>
-		<TextBlock FontStyle="Italic" Text="You can change your mind later through the Settings toolbar."/>
+		<TextBlock FontStyle="Italic" Text="You can change your mind later through the Settings."/>
 
 		<StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
 			<Button x:Name="SureButton" FontWeight="SemiBold" Click="SureButton_Click"

--- a/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml.cs
@@ -1,0 +1,38 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace TomodachiDrawer.UI.Avalonia;
+
+public partial class TelemetryPrompt : Window
+{
+    private bool _answered = false;
+
+    public TelemetryPrompt()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        if (!_answered)
+            e.Cancel = true;
+        base.OnClosing(e);
+    }
+
+    private void OpenSourceButton_Click(object? sender, RoutedEventArgs e)
+    {
+        Launcher.LaunchUriAsync(new Uri("https://github.com/Lucas7yoshi/TomodachiDrawer/blob/master/TomodachiDrawer.UI.Avalonia/TelemetryService.cs"));
+    }
+
+    private void NoThanksButton_Click(object? sender, RoutedEventArgs e)
+    {
+        _answered = true;
+        this.Close(false);
+    }
+
+    private void SureButton_Click(object? sender, RoutedEventArgs e)
+    {
+        _answered = true;
+        this.Close(true);
+    }
+}

--- a/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
@@ -28,7 +28,8 @@ namespace TomodachiDrawer.UI.Avalonia
             int? ColourLimit,
             string SwitchVersion,
             bool ExperimentalFeatures,
-            double TotalDrawTimeSeconds
+            double TotalDrawTimeSeconds,
+            double TspTimeLimit
         );
 
 

--- a/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
@@ -27,7 +27,8 @@ namespace TomodachiDrawer.UI.Avalonia
             string QuantizerMode,
             int? ColourLimit,
             string SwitchVersion,
-            bool ExperimentalFeatures
+            bool ExperimentalFeatures,
+            double TotalDrawTimeSeconds
         );
 
 

--- a/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http.Json;
+﻿using System.Net.Http.Json;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace TomodachiDrawer.UI.Avalonia
 {
@@ -14,7 +11,7 @@ namespace TomodachiDrawer.UI.Avalonia
 
         private const string TELEMETRY_URL = "https://telemetry.l7y.media/";
 
-        private HttpClient _http;
+        private readonly HttpClient _http;
 
         public record StartupEventDto(
             string Os,

--- a/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
@@ -1,9 +1,33 @@
-﻿using System.Net.Http.Json;
+using System.Net.Http.Json;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 namespace TomodachiDrawer.UI.Avalonia
 {
+    internal record StartupEventDto(
+        string Os,
+        string OsVersion,
+        string Arch,
+        string AppVersion
+    );
+
+    internal record ImageEventDto(
+        int ImageWidth,
+        int ImageHeight,
+        int ImageColourCount,
+        string QuantizerMode,
+        int? ColourLimit,
+        string SwitchVersion,
+        bool ExperimentalFeatures,
+        double TotalDrawTimeSeconds,
+        double TspTimeLimit
+    );
+
+    [JsonSerializable(typeof(StartupEventDto))]
+    [JsonSerializable(typeof(ImageEventDto))]
+    internal partial class TelemetryJsonContext : JsonSerializerContext { }
+
     /// <summary>TelemetryService handles reporting basic telemetry data to the developer. This is optional.</summary>
     internal class TelemetryService
     {
@@ -12,26 +36,6 @@ namespace TomodachiDrawer.UI.Avalonia
         private const string TELEMETRY_URL = "https://telemetry.l7y.media/";
 
         private readonly HttpClient _http;
-
-        public record StartupEventDto(
-            string Os,
-            string OsVersion,
-            string Arch,
-            string AppVersion
-        );
-
-        public record ImageEventDto(
-            int ImageWidth,
-            int ImageHeight,
-            int ImageColourCount,
-            string QuantizerMode,
-            int? ColourLimit,
-            string SwitchVersion,
-            bool ExperimentalFeatures,
-            double TotalDrawTimeSeconds,
-            double TspTimeLimit
-        );
-
 
         public TelemetryService()
         {
@@ -50,7 +54,6 @@ namespace TomodachiDrawer.UI.Avalonia
             if (!TelemetryEnabled)
                 return false;
 
-            // startup contains basic system/app info.
             string os = OperatingSystem.IsLinux() ? "Linux" :
                 OperatingSystem.IsWindows() ? "Windows" :
                 OperatingSystem.IsMacOS() ? "macOS" : "Unknown";
@@ -65,7 +68,7 @@ namespace TomodachiDrawer.UI.Avalonia
 
             try
             {
-                var response = await _http.PostAsJsonAsync("tomodachidrawer/startup", obj);
+                var response = await _http.PostAsJsonAsync("tomodachidrawer/startup", obj, TelemetryJsonContext.Default.StartupEventDto);
                 return response.IsSuccessStatusCode;
             }
             catch (Exception)
@@ -81,7 +84,7 @@ namespace TomodachiDrawer.UI.Avalonia
 
             try
             {
-                var response = await _http.PostAsJsonAsync("tomodachidrawer/image", imageData);
+                var response = await _http.PostAsJsonAsync("tomodachidrawer/image", imageData, TelemetryJsonContext.Default.ImageEventDto);
                 return response.IsSuccessStatusCode;
             }
             catch (Exception)

--- a/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
@@ -7,7 +7,7 @@ namespace TomodachiDrawer.UI.Avalonia
     /// <summary>TelemetryService handles reporting basic telemetry data to the developer. This is optional.</summary>
     internal class TelemetryService
     {
-        public static bool TelemetryEnabled { get; set; } = false;
+        public bool TelemetryEnabled { get; set; } = false;
 
         private const string TELEMETRY_URL = "https://telemetry.l7y.media/";
 
@@ -38,6 +38,7 @@ namespace TomodachiDrawer.UI.Avalonia
                 BaseAddress = new Uri(TELEMETRY_URL),
                 Timeout = TimeSpan.FromSeconds(3)
             };
+            _http.DefaultRequestHeaders.UserAgent.ParseAdd("TomodachiDrawer");
         }
 
         /// <summary>Sends startup data. Gets it all itself, just needs called.</summary>
@@ -62,8 +63,8 @@ namespace TomodachiDrawer.UI.Avalonia
 
             try
             {
-                await _http.PostAsJsonAsync("tomodachidrawer/startup", obj);
-                return true;
+                var response = await _http.PostAsJsonAsync("tomodachidrawer/startup", obj);
+                return response.IsSuccessStatusCode;
             }
             catch (Exception)
             {
@@ -78,8 +79,8 @@ namespace TomodachiDrawer.UI.Avalonia
 
             try
             {
-                await _http.PostAsJsonAsync("tomodachidrawer/image", imageData);
-                return true;
+                var response = await _http.PostAsJsonAsync("tomodachidrawer/image", imageData);
+                return response.IsSuccessStatusCode;
             }
             catch (Exception)
             {

--- a/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryService.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace TomodachiDrawer.UI.Avalonia
+{
+    /// <summary>TelemetryService handles reporting basic telemetry data to the developer. This is optional.</summary>
+    internal class TelemetryService
+    {
+        public static bool TelemetryEnabled { get; set; } = false;
+
+        private const string TELEMETRY_URL = "https://telemetry.l7y.media/";
+
+        private HttpClient _http;
+
+        public record StartupEventDto(
+            string Os,
+            string OsVersion,
+            string Arch,
+            string AppVersion
+        );
+
+        public record ImageEventDto(
+            int ImageWidth,
+            int ImageHeight,
+            int ImageColourCount,
+            string QuantizerMode,
+            int? ColourLimit,
+            string SwitchVersion,
+            bool ExperimentalFeatures
+        );
+
+
+        public TelemetryService()
+        {
+            _http = new HttpClient
+            {
+                BaseAddress = new Uri(TELEMETRY_URL),
+                Timeout = TimeSpan.FromSeconds(3)
+            };
+        }
+
+        /// <summary>Sends startup data. Gets it all itself, just needs called.</summary>
+        /// <returns>Sent or not</returns>
+        public async Task<bool> ReportStart()
+        {
+            if (!TelemetryEnabled)
+                return false;
+
+            // startup contains basic system/app info.
+            string os = OperatingSystem.IsLinux() ? "Linux" :
+                OperatingSystem.IsWindows() ? "Windows" :
+                OperatingSystem.IsMacOS() ? "macOS" : "Unknown";
+            string osVersion = RuntimeInformation.OSDescription;
+            string arch = RuntimeInformation.ProcessArchitecture.ToString();
+            var currentVersion =
+                Assembly
+                    .GetEntryAssembly()
+                    ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
+            var obj = new StartupEventDto(os, osVersion, arch, currentVersion ?? "unknown");
+
+            try
+            {
+                await _http.PostAsJsonAsync("tomodachidrawer/startup", obj);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public async Task<bool> ReportImage(ImageEventDto imageData)
+        {
+            if (!TelemetryEnabled)
+                return false;
+
+            try
+            {
+                await _http.PostAsJsonAsync("tomodachidrawer/image", imageData);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the beginning of the implementation of it.

This will not be merged until 3 days past the creation of #80 

May 26, 2026 1:44 PM EDT

The scope of this is:
- Startup (OS, OSVersion, AppVersion, Arch)
- General image data, excluding the image itself
  - Image size
  - Image colour count (from the input)
  - QuantizerMode
  - ColourLimit (for arbitrary colour)
  - Switch Version
  - Experimental Enabled

This will be completely optional and opt-in prompted at first startup. All telemetry reporting code will be open. 