### PR TITLE
Add Persist drawing option settings

### DIFF
--- a/TomodachiDrawer.UI.Avalonia/AppSettings.cs
+++ b/TomodachiDrawer.UI.Avalonia/AppSettings.cs
@@ -13,6 +13,16 @@ internal class AppSettings
 
     public bool CheckForUpdatesOnStart { get; set; } = true;
 
+    public string SelectedColourMatcher { get; set; } = "Arbitrary";
+
+    public int ColourLimit { get; set; } = 16;
+
+    public string SelectedDenoiser { get; set; } = "None";
+
+    public bool? AutoHomeCanvasToTopLeft { get; set; } = null;
+
+    public float? TspSolverTimeLimit { get; set; } = null;
+
     public int FirstStartId { get; set; } = 0;
 
     /// <summary>This is null by default to indicate they havent been asked yet.</summary>

--- a/TomodachiDrawer.UI.Avalonia/AppSettings.cs
+++ b/TomodachiDrawer.UI.Avalonia/AppSettings.cs
@@ -19,10 +19,6 @@ internal class AppSettings
 
     public string SelectedDenoiser { get; set; } = "None";
 
-    public bool? AutoHomeCanvasToTopLeft { get; set; } = null;
-
-    public float? TspSolverTimeLimit { get; set; } = null;
-
     public int FirstStartId { get; set; } = 0;
 
     /// <summary>This is null by default to indicate they havent been asked yet.</summary>

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
@@ -149,8 +149,7 @@
 							<NumericUpDown x:Name="TSPTimeLimitUpDown"
 										   Minimum="0.1" Maximum="30"
 										   Increment="0.1" Value="0.5"
-										   FormatString="F1"
-										   Width="110"
+											Width="110" />
 										   ValueChanged="TSPTimeLimitUpDown_ValueChanged" />
 							<TextBlock Text="seconds"
 									   VerticalAlignment="Center" />

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
@@ -150,7 +150,8 @@
 										   Minimum="0.1" Maximum="30"
 										   Increment="0.1" Value="0.5"
 										   FormatString="F1"
-										   Width="110" />
+										   Width="110"
+										   ValueChanged="TSPTimeLimitUpDown_ValueChanged" />
 							<TextBlock Text="seconds"
 									   VerticalAlignment="Center" />
 							<Button Content="?"

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml
@@ -150,7 +150,6 @@
 										   Minimum="0.1" Maximum="30"
 										   Increment="0.1" Value="0.5"
 											Width="110" />
-										   ValueChanged="TSPTimeLimitUpDown_ValueChanged" />
 							<TextBlock Text="seconds"
 									   VerticalAlignment="Center" />
 							<Button Content="?"

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -669,7 +669,6 @@ public partial class MainWindow : Window
         if (_currentImage != null)
             await UpdatePreviewAsync();
         ColourLimitUpDown.IsEnabled =
-        ColourLimitUpDown.IsEnabled =
             ColourMatcherComboBox?.SelectedValue?.ToString() == "Arbitrary";
 
         if (!_loadingSettings && ColourMatcherComboBox.SelectedItem?.ToString() is { } selectedColourMatcher)

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -516,19 +516,15 @@ public partial class MainWindow : Window
         RP2040ExportUF2Button.IsEnabled = true;
         RP2350ExportUF2Button.IsEnabled = true;
 
-        if (_currentSettings.AutoHomeCanvasToTopLeft == null && img.Width == 256 && img.Height == 256)
+        if (img.Width == 256 && img.Height == 256)
         {
             AppendLog("Image is full canvas size, so enabling auto home by default.\nYou can disable it if it causes you trouble and manually home before connecting.");
-            SetControlValueWithoutSaving(() => EnableHomeCanvas.IsChecked = true);
+            EnableHomeCanvas.IsChecked = true;
         }
 
         await UpdatePreviewAsync();
-        if (_currentSettings.TspSolverTimeLimit == null)
-        {
-            SetControlValueWithoutSaving(() =>
-                TSPTimeLimitUpDown.Value = (decimal)
-                    CanvasDrawer.GetRecommendedTSPSolveTime(img.Width, img.Height));
-        }
+        TSPTimeLimitUpDown.Value = (decimal)
+            CanvasDrawer.GetRecommendedTSPSolveTime(img.Width, img.Height);
         AppendLog($"Loaded image: {displayName} ({img.Width}x{img.Height})");
     }
 
@@ -1089,18 +1085,6 @@ public partial class MainWindow : Window
             _ = UpdatePreviewAsync();
     }
 
-    private void TSPTimeLimitUpDown_ValueChanged(
-        object? sender,
-        NumericUpDownValueChangedEventArgs e
-    )
-    {
-        if (_loadingSettings)
-            return;
-
-        _currentSettings.TspSolverTimeLimit = (float)(TSPTimeLimitUpDown.Value ?? 0.5m);
-        SaveSettings();
-    }
-
     private void ThemeMenuItem_Click(object? sender, RoutedEventArgs e)
     {
         int index = sender == ThemeLightMenuItem ? 1 : sender == ThemeDarkMenuItem ? 2 : 0;
@@ -1218,10 +1202,6 @@ public partial class MainWindow : Window
             ColourLimitUpDown.IsEnabled =
                 ColourMatcherComboBox?.SelectedValue?.ToString() == "Arbitrary";
             SelectComboBoxItem(DenoisingComboBox, _currentSettings.SelectedDenoiser);
-            EnableHomeCanvas.IsChecked = _currentSettings.AutoHomeCanvasToTopLeft;
-
-            if (_currentSettings.TspSolverTimeLimit != null)
-                TSPTimeLimitUpDown.Value = (decimal)_currentSettings.TspSolverTimeLimit.Value;
         }
         finally
         {
@@ -1444,11 +1424,6 @@ public partial class MainWindow : Window
     private void EnableHomeCanvas_IsCheckedChanged(object? sender, RoutedEventArgs e)
     {
         // TODO: Notify if non 256x256 image.
-        if (_loadingSettings)
-            return;
-
-        _currentSettings.AutoHomeCanvasToTopLeft = EnableHomeCanvas.IsChecked ?? false;
-        SaveSettings();
     }
 
     private async void OpenTelemetryPrompt_Click(object? sender, RoutedEventArgs e)

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -671,7 +671,7 @@ public partial class MainWindow : Window
         ColourLimitUpDown.IsEnabled =
             ColourMatcherComboBox?.SelectedValue?.ToString() == "Arbitrary";
 
-        if (!_loadingSettings && ColourMatcherComboBox.SelectedItem?.ToString() is { } selectedColourMatcher)
+        if (!_loadingSettings && ColourMatcherComboBox?.SelectedItem?.ToString() is { } selectedColourMatcher)
         {
             _currentSettings.SelectedColourMatcher = selectedColourMatcher;
             SaveSettings();
@@ -683,7 +683,7 @@ public partial class MainWindow : Window
         if (_currentImage != null)
             await UpdatePreviewAsync();
 
-        if (!_loadingSettings && DenoisingComboBox.SelectedItem?.ToString() is { } selectedDenoiser)
+        if (!_loadingSettings && DenoisingComboBox?.SelectedItem?.ToString() is { } selectedDenoiser)
         {
             _currentSettings.SelectedDenoiser = selectedDenoiser;
             SaveSettings();

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -45,7 +45,8 @@ public partial class MainWindow : Window
 
     //private SwitchVersion _selectedSwitchVersion = SwitchVersion.None;
     //private int _selectedThemeIndex = 0; // 0 is System.
-    private AppSettings _currentSettings = new(); // All cases will result in it being non-null but IntelliSense cant see that far.
+    private AppSettings _currentSettings = new(); // All cases will result in it being non-null but IntelliSense cant see that far
+    private bool _loadingSettings = true;
 
 #if DEBUG
     private readonly VirtualGamepad _debugVirtualGamepad = new();
@@ -59,17 +60,20 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
 
-        var quantizers = ColourPalette.Quantizers.Keys.ToList();
-        quantizers.Insert(0, "Arbitrary");
-        ColourMatcherComboBox.ItemsSource = quantizers;
-        ColourMatcherComboBox.SelectedIndex = 0;
+        SetControlValueWithoutSaving(() =>
+        {
+            var quantizers = ColourPalette.Quantizers.Keys.ToList();
+            quantizers.Insert(0, "Arbitrary");
+            ColourMatcherComboBox.ItemsSource = quantizers;
+            ColourMatcherComboBox.SelectedIndex = 0;
 
-        var denoiserSelection = new List<string> { "None" };
-        denoiserSelection.AddRange(ImageDenoiser.Denoisers.Keys);
+            var denoiserSelection = new List<string> { "None" };
+            denoiserSelection.AddRange(ImageDenoiser.Denoisers.Keys);
 
-        DenoisingComboBox.ItemsSource = denoiserSelection;
-        DenoisingComboBox.SelectedIndex = 0;
-        DenoisingComboBox.SelectionChanged += async (_, _) => await UpdatePreviewAsync();
+            DenoisingComboBox.ItemsSource = denoiserSelection;
+            DenoisingComboBox.SelectedIndex = 0;
+            DenoisingComboBox.SelectionChanged += DenoisingComboBox_SelectionChanged;
+        });
 
         InitializeTemplates();
 
@@ -78,6 +82,7 @@ public partial class MainWindow : Window
         DragDrop.SetAllowDrop(this, true);
         AddHandler(DragDrop.DropEvent, OnDrop);
         AddHandler(DragDrop.DragOverEvent, OnDragOver);
+
 
 #if DEBUG
         this.Title = $"TomodachiDrawer.UI.Avalonia - {GetVersionString(true)}";
@@ -511,15 +516,19 @@ public partial class MainWindow : Window
         RP2040ExportUF2Button.IsEnabled = true;
         RP2350ExportUF2Button.IsEnabled = true;
 
-        if (img.Width == 256 && img.Height == 256)
+        if (_currentSettings.AutoHomeCanvasToTopLeft == null && img.Width == 256 && img.Height == 256)
         {
             AppendLog("Image is full canvas size, so enabling auto home by default.\nYou can disable it if it causes you trouble and manually home before connecting.");
-            EnableHomeCanvas.IsChecked = true;
+            SetControlValueWithoutSaving(() => EnableHomeCanvas.IsChecked = true);
         }
 
         await UpdatePreviewAsync();
-        TSPTimeLimitUpDown.Value = (decimal)
-            CanvasDrawer.GetRecommendedTSPSolveTime(img.Width, img.Height);
+        if (_currentSettings.TspSolverTimeLimit == null)
+        {
+            SetControlValueWithoutSaving(() =>
+                TSPTimeLimitUpDown.Value = (decimal)
+                    CanvasDrawer.GetRecommendedTSPSolveTime(img.Width, img.Height));
+        }
         AppendLog($"Loaded image: {displayName} ({img.Width}x{img.Height})");
     }
 
@@ -664,7 +673,26 @@ public partial class MainWindow : Window
         if (_currentImage != null)
             await UpdatePreviewAsync();
         ColourLimitUpDown.IsEnabled =
+        ColourLimitUpDown.IsEnabled =
             ColourMatcherComboBox?.SelectedValue?.ToString() == "Arbitrary";
+
+        if (!_loadingSettings && ColourMatcherComboBox.SelectedItem?.ToString() is { } selectedColourMatcher)
+        {
+            _currentSettings.SelectedColourMatcher = selectedColourMatcher;
+            SaveSettings();
+        }
+    }
+
+    private async void DenoisingComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_currentImage != null)
+            await UpdatePreviewAsync();
+
+        if (!_loadingSettings && DenoisingComboBox.SelectedItem?.ToString() is { } selectedDenoiser)
+        {
+            _currentSettings.SelectedDenoiser = selectedDenoiser;
+            SaveSettings();
+        }
     }
 
     private void TSPHelpButton_Click(object? sender, RoutedEventArgs e)
@@ -1046,7 +1074,29 @@ public partial class MainWindow : Window
     private void ColourLimitUpDown_ValueChanged(
         object? sender,
         NumericUpDownValueChangedEventArgs e
-    ) => _ = UpdatePreviewAsync();
+    )
+    {
+        if (!_loadingSettings)
+        {
+            _currentSettings.ColourLimit = (int)(ColourLimitUpDown.Value ?? 16);
+            SaveSettings();
+        }
+
+        if (_currentImage != null)
+            _ = UpdatePreviewAsync();
+    }
+
+    private void TSPTimeLimitUpDown_ValueChanged(
+        object? sender,
+        NumericUpDownValueChangedEventArgs e
+    )
+    {
+        if (_loadingSettings)
+            return;
+
+        _currentSettings.TspSolverTimeLimit = (float)(TSPTimeLimitUpDown.Value ?? 0.5m);
+        SaveSettings();
+    }
 
     private void ThemeMenuItem_Click(object? sender, RoutedEventArgs e)
     {
@@ -1146,24 +1196,77 @@ public partial class MainWindow : Window
         // if no images or we fail, fall to defaults in the appsettings class.
         _currentSettings ??= new AppSettings();
 
-        SwitchVersionComboBox.SelectedIndex =
-            (int)_currentSettings.SelectedSwitchVersion - 1;
-        SetTheme(_currentSettings.SelectedThemeIndex);
-        ThemeSystemMenuItem.IsChecked = _currentSettings.SelectedThemeIndex == 0;
-        ThemeLightMenuItem.IsChecked = _currentSettings.SelectedThemeIndex == 1;
-        ThemeDarkMenuItem.IsChecked = _currentSettings.SelectedThemeIndex == 2;
+        _loadingSettings = true;
+        try
+        {
+            SwitchVersionComboBox.SelectedIndex =
+                (int)_currentSettings.SelectedSwitchVersion - 1;
+            SetTheme(_currentSettings.SelectedThemeIndex);
+            ThemeSystemMenuItem.IsChecked = _currentSettings.SelectedThemeIndex == 0;
+            ThemeLightMenuItem.IsChecked = _currentSettings.SelectedThemeIndex == 1;
+            ThemeDarkMenuItem.IsChecked = _currentSettings.SelectedThemeIndex == 2;
 
-        EnableExperimentalMenuItem.IsChecked =
-            _currentSettings.EnableExperimentalFeatures;
-        CheckForUpdatesCheckBox.IsChecked = _currentSettings.CheckForUpdatesOnStart;
+            EnableExperimentalMenuItem.IsChecked =
+                _currentSettings.EnableExperimentalFeatures;
+            CheckForUpdatesCheckBox.IsChecked = _currentSettings.CheckForUpdatesOnStart;
+
+            SelectComboBoxItem(ColourMatcherComboBox, _currentSettings.SelectedColourMatcher);
+            ColourLimitUpDown.Value = _currentSettings.ColourLimit;
+            ColourLimitUpDown.IsEnabled =
+                ColourMatcherComboBox?.SelectedValue?.ToString() == "Arbitrary";
+            SelectComboBoxItem(DenoisingComboBox, _currentSettings.SelectedDenoiser);
+            EnableHomeCanvas.IsChecked = _currentSettings.AutoHomeCanvasToTopLeft;
+
+            if (_currentSettings.TspSolverTimeLimit != null)
+                TSPTimeLimitUpDown.Value = (decimal)_currentSettings.TspSolverTimeLimit.Value;
+        }
+        finally
+        {
+            _loadingSettings = false;
+        }
+    }
+
+    private static void SelectComboBoxItem(ComboBox comboBox, string selectedItem)
+    {
+        var index = 0;
+        foreach (var item in comboBox.Items)
+        {
+            if (item?.ToString() == selectedItem)
+            {
+                comboBox.SelectedIndex = index;
+                return;
+            }
+
+            index++;
+        }
+    }
+
+    private void SetControlValueWithoutSaving(Action setControlValue)
+    {
+        var wasLoadingSettings = _loadingSettings;
+        _loadingSettings = true;
+        try
+        {
+            setControlValue();
+        }
+        finally
+        {
+            _loadingSettings = wasLoadingSettings;
+        }
     }
 
     private void SwitchVersionComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
+        if (_loadingSettings)
+            return;
+
         if (SwitchVersionComboBox.SelectedIndex == 0)
             _currentSettings.SelectedSwitchVersion = SwitchVersion.Switch1;
-        else
+        else if (SwitchVersionComboBox.SelectedIndex == 1)
             _currentSettings.SelectedSwitchVersion = SwitchVersion.Switch2;
+        else
+            _currentSettings.SelectedSwitchVersion = SwitchVersion.None;
+
         SaveSettings();
     }
 
@@ -1338,6 +1441,11 @@ public partial class MainWindow : Window
     private void EnableHomeCanvas_IsCheckedChanged(object? sender, RoutedEventArgs e)
     {
         // TODO: Notify if non 256x256 image.
+        if (_loadingSettings)
+            return;
+
+        _currentSettings.AutoHomeCanvasToTopLeft = EnableHomeCanvas.IsChecked ?? false;
+        SaveSettings();
     }
 
     private async void OpenTelemetryPrompt_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
This Pull Request adds persistence for some options through `settings.json`, so they don't need to be reconfigured every time the program is launched.

Things like the TSP Solver Time Limit, Colour Limit, Colour Matcher, Denoising, and Auto Home Canvas to Top Left now save when the program is closed.
