### PR TITLE
feat(ui): Add sentry crash logging

### DIFF
--- a/TomodachiDrawer.UI.Avalonia/App.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/App.axaml.cs
@@ -10,6 +10,7 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        CrashReporter.CaptureUIThreadExceptions();
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             desktop.MainWindow = new MainWindow();
         base.OnFrameworkInitializationCompleted();

--- a/TomodachiDrawer.UI.Avalonia/AppSettings.cs
+++ b/TomodachiDrawer.UI.Avalonia/AppSettings.cs
@@ -31,7 +31,10 @@ internal class AppSettings
 
         if (OperatingSystem.IsMacOS() && AppContext.BaseDirectory.Contains(".app/Contents/MacOS"))
         {
-            var appDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TomodachiDrawer");
+            var appDataFolder = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "TomodachiDrawer"
+            );
             if (!Directory.Exists(appDataFolder))
             {
                 Directory.CreateDirectory(appDataFolder);

--- a/TomodachiDrawer.UI.Avalonia/AppSettings.cs
+++ b/TomodachiDrawer.UI.Avalonia/AppSettings.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using TomodachiDrawer.Core.Models;
 
@@ -23,6 +24,42 @@ internal class AppSettings
 
     /// <summary>This is null by default to indicate they havent been asked yet.</summary>
     public bool? EnableTelemetry { get; set; } = null;
+
+    internal static string GetSettingsFilePath()
+    {
+        const string settingsFileName = "settings.json";
+
+        if (OperatingSystem.IsMacOS() && AppContext.BaseDirectory.Contains(".app/Contents/MacOS"))
+        {
+            var appDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TomodachiDrawer");
+            if (!Directory.Exists(appDataFolder))
+            {
+                Directory.CreateDirectory(appDataFolder);
+            }
+            return Path.Combine(appDataFolder, settingsFileName);
+        }
+        else
+        {
+            return settingsFileName;
+        }
+    }
+
+    internal static AppSettings? TryLoad()
+    {
+        var path = GetSettingsFilePath();
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize(json, AppSettingsContext.Default.AppSettings);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
 }
 
 // Source gen serialization to avoid trimming warnings.

--- a/TomodachiDrawer.UI.Avalonia/CrashReporter.cs
+++ b/TomodachiDrawer.UI.Avalonia/CrashReporter.cs
@@ -1,0 +1,116 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace TomodachiDrawer.UI.Avalonia;
+
+internal static partial class CrashReporter
+{
+    private const string DSN = "https://d21cb41981a5038b6044d62c0dd4deb9@o82037.ingest.us.sentry.io/4511475971325952";
+
+    private static bool _initialized;
+
+    // As an extra layer of precaution, we manually scrub PII (the username) as well as using SendDefaultPii = false.
+    // I do not want to be a nuisance to users by sending that stuff, plus it poses some legal concerns. Best to be safe.
+    [GeneratedRegex(@"([A-Za-z]:\\Users\\|[/\\]home[/\\]|/Users/)[^\\/]+", RegexOptions.IgnoreCase)]
+    private static partial Regex UserPathRegex();
+
+    private static readonly string HomeDir =
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    public static void Init()
+    {
+        if (_initialized)
+            return;
+        if (string.IsNullOrEmpty(DSN) )
+            return;
+
+        var version =
+            Assembly
+                .GetEntryAssembly()
+                ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion
+            ?? "unknown";
+
+        SentrySdk.Init(o =>
+        {
+            o.Dsn = DSN;
+
+            o.SendDefaultPii = false;
+#if DEBUG
+            o.ServerName = "a_developer";
+#else
+            o.ServerName = "a_user";
+#endif
+
+            o.IsGlobalModeEnabled = true;
+
+            o.AutoSessionTracking = false;
+
+            o.Release = version;
+#if DEBUG
+            o.Environment = "debug";
+#else
+            o.Environment = "release";
+#endif
+
+            o.SetBeforeSend(Scrub);
+        });
+
+        _initialized = true;
+    }
+
+    public static void Disable()
+    {
+        if (!_initialized)
+            return;
+
+        SentrySdk.Close();
+        _initialized = false;
+    }
+
+    public static void Flush()
+    {
+        if (!_initialized)
+            return;
+
+        SentrySdk.Flush(TimeSpan.FromSeconds(2));
+        SentrySdk.Close();
+        _initialized = false;
+    }
+
+    private static SentryEvent? Scrub(SentryEvent e, SentryHint hint)
+    {
+        e.ServerName = null;
+
+        // scrub everything
+        if (e.Message != null)
+        {
+            e.Message.Message = ScrubText(e.Message.Message);
+            e.Message.Formatted = ScrubText(e.Message.Formatted);
+        }
+        // and anything
+        foreach (var ex in e.SentryExceptions ?? [])
+        {
+            ex.Value = ScrubText(ex.Value);
+
+            foreach (var frame in ex.Stacktrace?.Frames ?? [])
+            {
+                frame.FileName = ScrubText(frame.FileName);
+                frame.AbsolutePath = ScrubText(frame.AbsolutePath);
+            }
+        }
+
+        return e;
+    }
+
+    private static string? ScrubText(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input;
+
+        if (!string.IsNullOrEmpty(HomeDir))
+            input = input.Replace(HomeDir, "~", StringComparison.OrdinalIgnoreCase);
+
+        return UserPathRegex().Replace(input, "$1<user>");
+    }
+}

--- a/TomodachiDrawer.UI.Avalonia/CrashReporter.cs
+++ b/TomodachiDrawer.UI.Avalonia/CrashReporter.cs
@@ -6,7 +6,8 @@ namespace TomodachiDrawer.UI.Avalonia;
 
 internal static partial class CrashReporter
 {
-    private const string DSN = "https://d21cb41981a5038b6044d62c0dd4deb9@o82037.ingest.us.sentry.io/4511475971325952";
+    private const string DSN =
+        "https://d21cb41981a5038b6044d62c0dd4deb9@o82037.ingest.us.sentry.io/4511475971325952";
 
     private static bool _initialized;
 
@@ -15,14 +16,15 @@ internal static partial class CrashReporter
     [GeneratedRegex(@"([A-Za-z]:\\Users\\|[/\\]home[/\\]|/Users/)[^\\/]+", RegexOptions.IgnoreCase)]
     private static partial Regex UserPathRegex();
 
-    private static readonly string HomeDir =
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    private static readonly string HomeDir = Environment.GetFolderPath(
+        Environment.SpecialFolder.UserProfile
+    );
 
     public static void Init()
     {
         if (_initialized)
             return;
-        if (string.IsNullOrEmpty(DSN) )
+        if (string.IsNullOrEmpty(DSN))
             return;
 
         var version =

--- a/TomodachiDrawer.UI.Avalonia/CrashReporter.cs
+++ b/TomodachiDrawer.UI.Avalonia/CrashReporter.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Avalonia.Threading;
 
 namespace TomodachiDrawer.UI.Avalonia;
 
@@ -77,6 +78,9 @@ internal static partial class CrashReporter
         SentrySdk.Close();
         _initialized = false;
     }
+
+    public static void CaptureUIThreadExceptions() =>
+        Dispatcher.UIThread.UnhandledException += (_, e) => SentrySdk.CaptureException(e.Exception);
 
     private static SentryEvent? Scrub(SentryEvent e, SentryHint hint)
     {

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -194,6 +194,11 @@ public partial class MainWindow : Window
         if (_currentSettings.EnableTelemetry == true)
         {
             _telemetry.TelemetryEnabled = true;
+            // Turn on crash reporting if not already initialized.
+            // We explicitly do NOT start it on first-launch before the user has had a chance to consent.
+            // This does come with the downside that we would probably not be able to receive right-at-start errors, but those
+            // haven't really been an issue and can deal with those the ol fashioned way.
+            CrashReporter.Init();
             // Discard to avoid blocking.
             _ = _telemetry.ReportStart();
         }
@@ -1167,68 +1172,26 @@ public partial class MainWindow : Window
         );
     }
 
-    private static string GetSettingsFilePath()
-    {
-        const string settingsFileName = "settings.json";
-
-        // Check if we're running on macOS and the app is running from the app bundle, not CLI.
-        if (OperatingSystem.IsMacOS() && AppContext.BaseDirectory.Contains(".app/Contents/MacOS"))
-        {
-            // In macOS, when you launch `.app` from Finder, the current working directory is root directory `/` (Gemini said),
-            // which is read-only and not a good place to store our settings file.
-            // We need to place the settings file somewhere else.
-            // `~/Library/Application Support` is a common place to store app data on macOS (like `%APPDATA%` on Windows).
-            // So first, ensure `~/Library/Application Support/TomodachiDrawer` exists
-            var appDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "TomodachiDrawer"
-            );
-            if (!Directory.Exists(appDataFolder))
-            {
-                Directory.CreateDirectory(appDataFolder);
-            }
-            // Returns `~/Library/Application Support/TomodachiDrawer/settings.json`
-            return Path.Combine(appDataFolder, settingsFileName);
-        }
-        else
-        {
-            // Simply place it in the current working directory
-            return settingsFileName;
-        }
-    }
-
     private void SaveSettings()
     {
         var json = JsonSerializer.Serialize(
             _currentSettings,
             AppSettingsContext.Default.AppSettings
         );
-        File.WriteAllText(GetSettingsFilePath(), json);
+        File.WriteAllText(AppSettings.GetSettingsFilePath(), json);
     }
 
     private void GetSettings()
     {
-        var settingsFilePath = GetSettingsFilePath();
-
-        if (File.Exists(settingsFilePath))
+        var settings = AppSettings.TryLoad();
+        if (settings != null)
         {
-            try
-            {
-                var json = File.ReadAllText(settingsFilePath);
-                var settings = JsonSerializer.Deserialize(
-                    json,
-                    AppSettingsContext.Default.AppSettings
-                );
-
-                if (settings != null)
-                {
-                    _currentSettings = settings;
-                }
-            }
-            catch (Exception)
-            {
-                AppendLog("Failed to load settings. Using defaults.");
-            }
+            _currentSettings = settings;
+        }
+        else if (File.Exists(AppSettings.GetSettingsFilePath()))
+        {
+            // File exists but failed to parse; keep defaults but let the user know.
+            AppendLog("Failed to load settings. Using defaults.");
         }
 
         // if no images or we fail, fall to defaults in the appsettings class.
@@ -1493,6 +1456,11 @@ public partial class MainWindow : Window
         var answer = await new TelemetryPrompt().ShowDialog<bool>(this);
         _currentSettings.EnableTelemetry = answer;
         _telemetry.TelemetryEnabled = answer;
+        // Keep crash reporting in lock-step with the consent answer, no restart needed.
+        if (answer)
+            CrashReporter.Init();
+        else
+            CrashReporter.Disable();
         SaveSettings();
     }
 

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -25,7 +25,6 @@ using Button = Avalonia.Controls.Button; // conflict with the Button enum in Sin
 using TomodachiDrawer.DebugTools;
 #endif
 
-
 namespace TomodachiDrawer.UI.Avalonia;
 
 public partial class MainWindow : Window

--- a/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
+++ b/TomodachiDrawer.UI.Avalonia/MainWindow.axaml.cs
@@ -1445,17 +1445,14 @@ public partial class MainWindow : Window
     private void MenuHelpCheckForUpdate_Click(object? sender, RoutedEventArgs e) =>
         _ = PerformAsyncUpdateCheck();
 
-    private void EnableHomeCanvas_IsCheckedChanged(object? sender, RoutedEventArgs e)
-    {
-        // TODO: Notify if non 256x256 image.
-    }
+    private void EnableHomeCanvas_IsCheckedChanged(object? sender, RoutedEventArgs e) { }
 
     private async void OpenTelemetryPrompt_Click(object? sender, RoutedEventArgs e)
     {
         var answer = await new TelemetryPrompt().ShowDialog<bool>(this);
         _currentSettings.EnableTelemetry = answer;
         _telemetry.TelemetryEnabled = answer;
-        // Keep crash reporting in lock-step with the consent answer, no restart needed.
+        // Inform the crash reporter if we change anything
         if (answer)
             CrashReporter.Init();
         else

--- a/TomodachiDrawer.UI.Avalonia/Program.cs
+++ b/TomodachiDrawer.UI.Avalonia/Program.cs
@@ -6,8 +6,25 @@ namespace TomodachiDrawer.UI.Avalonia
     {
         // The entry point for the actual application
         [STAThread]
-        public static void Main(string[] args) =>
-            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        public static void Main(string[] args)
+        {
+            // Initialize crash reporting as early as possible so startup crashes are
+            // caught, but ONLY IF THE USER HAS CONSENTED TO SUCH THINGS!
+            // This is arguably not ideal since it means if a user cant launch the program at all, we wouldn't
+            // be aware of it, but the alternative involves implicit consent which feels icky.
+            if (AppSettings.TryLoad()?.EnableTelemetry == true)
+                CrashReporter.Init();
+
+            try
+            {
+                BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+            }
+            finally
+            {
+                // Deliver any queued crash events before the process dies.
+                CrashReporter.Flush();
+            }
+        }
 
         // The entry point the Previewer looks for
         public static AppBuilder BuildAvaloniaApp() =>

--- a/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
+++ b/TomodachiDrawer.UI.Avalonia/TelemetryPrompt.axaml
@@ -11,7 +11,7 @@
 	<StackPanel Margin="16" Spacing="12">
 		<TextBlock FontWeight="SemiBold" FontSize="15" Text="Help improve Tomodachi Drawer?" />
 		<TextBlock TextWrapping="Wrap"
-				   Text="Anonymous usage data helps me to better understand how the app is used and know where to focus development efforts. No personal data is collected."
+				   Text="Anonymous usage data and crash reports help me to better understand how the app is used, fix bugs, and know where to focus development efforts. No personal data is collected."
 				   />
 
 		<Expander Header="What's collected?" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
@@ -29,7 +29,11 @@
 				<TextBlock Text="  - Draw time estimate" />
 				<TextBlock Text="  - TSP Time Limit" />
 				<TextBlock Text="  - Which chip used (RP2040/RP2350)" />
-				<TextBlock Text="  - App version" />	
+				<TextBlock Text="  - App version" />
+				<TextBlock FontWeight="SemiBold" Margin="0,4,0,0" Text="If the app crashes:" />
+				<TextBlock Text="  - The error type, message, and stack trace" />
+				<TextBlock Text="  - App version and operating system" />
+				<TextBlock FontStyle="Italic" TextWrapping="Wrap" Text="  Your username and file paths are removed from crash reports before they are sent. This data is handled by Sentry." />
 			</StackPanel>
 		</Expander>
 

--- a/TomodachiDrawer.UI.Avalonia/TomodachiDrawer.UI.Avalonia.csproj
+++ b/TomodachiDrawer.UI.Avalonia/TomodachiDrawer.UI.Avalonia.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="Sentry" Version="6.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TomodachiDrawer.Core\TomodachiDrawer.Core.csproj" />

--- a/build commands.txt
+++ b/build commands.txt
@@ -1,5 +1,0 @@
-dotnet publish -c Release --self-contained -r win-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugSymbols=false -p:DebugType=none
-dotnet publish -c Release --self-contained -r osx-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugSymbols=false -p:DebugType=none
-dotnet publish -c Release --self-contained -r osx-arm64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugSymbols=false -p:DebugType=none
-dotnet publish -c Release --self-contained -r linux-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugSymbols=false -p:DebugType=none
-dotnet publish -c Release --self-contained -r linux-arm64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugSymbols=false -p:DebugType=none


### PR DESCRIPTION
Conservatively enables only once the user has first consented to telemetry. Wrapped up for simplicities sake in the telemetry UI.

This will likely be broken by #107 which i will fix once that is merged.

This is to help with the... unfortunately common trend of reporting issues but not really reporting crashes...